### PR TITLE
Fix MC1243 (Distributor) off-by-one error (#1183)

### DIFF
--- a/src/main/java/com/sk89q/craftbook/mechanics/ic/gates/world/items/Distributer.java
+++ b/src/main/java/com/sk89q/craftbook/mechanics/ic/gates/world/items/Distributer.java
@@ -112,9 +112,9 @@ public class Distributer extends AbstractSelfTriggeredIC implements PipeInputIC 
 
         currentIndex++;
         getSign().setLine(3, String.valueOf(currentIndex));
-        if (currentIndex >= left && currentIndex <= left+right)
+        if (currentIndex >= left && currentIndex < left+right)
             return true;
-        else if (currentIndex <= left)
+        else if (currentIndex < left)
             return false;
         else {
             currentIndex = 0;


### PR DESCRIPTION
* Would distribute right+1 to the right before

Co-authored-by: Apeiron <apeiron@none>